### PR TITLE
feature/pass bookmark values to xcom

### DIFF
--- a/vivian_airflow_extensions/hooks/s3_bookmark_hook.py
+++ b/vivian_airflow_extensions/hooks/s3_bookmark_hook.py
@@ -9,6 +9,7 @@ class S3BookmarkHook(BaseHook):
     This class interacts with S3 to get and save bookmarks.
     """
     template_fields = ['bookmark_s3_key']
+    format_string = '%Y-%m-%d %H:%M:%S'
 
     @apply_defaults
     def __init__(self, bookmark_s3_key: str=None, incremental_key_type: str=None, *args, **kwargs) -> None:
@@ -61,7 +62,7 @@ class S3BookmarkHook(BaseHook):
             self.log.info('Bookmark is None, not saving it')
             return
         else:
-            bookmark = bookmark.strftime('%Y-%m-%d %H:%M:%S')
+            bookmark = bookmark.strftime(self.format_string)
 
         s3 = s3fs.S3FileSystem(anon=False)
 

--- a/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
+++ b/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
@@ -199,10 +199,12 @@ class SnowflakeToPostgresBookmarkOperator(SnowflakeToPostgresMergeIncrementalOpe
         self.s3_bookmark_hook.save_next_bookmark(next_bookmark)
 
         self.xcom_push(
+            context,
             key='previous_bookmark',
             value=latest_bookmark
         )
         self.xcom_push(
+            context,
             key='next_bookmark',
             value=next_bookmark
         )

--- a/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
+++ b/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
@@ -206,5 +206,5 @@ class SnowflakeToPostgresBookmarkOperator(SnowflakeToPostgresMergeIncrementalOpe
         self.xcom_push(
             context,
             key='next_bookmark',
-            value=next_bookmark
+            value=next_bookmark.strftime(self.s3_bookmark_hook.format_string)
         )

--- a/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
+++ b/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
@@ -201,7 +201,7 @@ class SnowflakeToPostgresBookmarkOperator(SnowflakeToPostgresMergeIncrementalOpe
         self.xcom_push(
             context,
             key='previous_bookmark',
-            value=latest_bookmark
+            value=latest_bookmark.replace("'", "")
         )
         self.xcom_push(
             context,

--- a/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
+++ b/vivian_airflow_extensions/operators/snowflake_to_postgres_operator.py
@@ -197,3 +197,12 @@ class SnowflakeToPostgresBookmarkOperator(SnowflakeToPostgresMergeIncrementalOpe
         super().execute(context)
 
         self.s3_bookmark_hook.save_next_bookmark(next_bookmark)
+
+        self.xcom_push(
+            key='previous_bookmark',
+            value=latest_bookmark
+        )
+        self.xcom_push(
+            key='next_bookmark',
+            value=next_bookmark
+        )


### PR DESCRIPTION
With the bookmark operator, both the previous and the current bookmark now get passed to xcom as strings. Ex:
![image](https://github.com/user-attachments/assets/750e86eb-8644-4d2a-a4dd-2c018789daad)
